### PR TITLE
Fix cross-join bug in compute_virtual_machine_long_running control's query

### DIFF
--- a/controls/compute.sp
+++ b/controls/compute.sp
@@ -293,7 +293,8 @@ control "compute_virtual_machine_long_running" {
       jsonb_array_elements(statuses) as s,
       azure_subscription as sub
     where
-      vm.power_state in ('running', 'starting')
+      sub.subscription_id = vm.subscription_id
+      and vm.power_state in ('running', 'starting')
       and s ->> 'time' is not null;
   EOT
 


### PR DESCRIPTION
This PR fixes a bug in the `compute_virtual_machine_long_running` control's query: 

This control's query scans both the `azure_compute_virtual_machine` and `azure_subscription` tables (for the purpose of looking up the subscription name from the subscription ID), but the query's `where` clause is missing a join condition between these tables. As a result, the existing query returns the cross-product of the long-running VMs and the subscriptions (so each VM is output multiple times, one for each subscription).

This PR fixes this bug by adding a `sub.subscription_id = vm.subscription_id` condition (similar to the other queries in this file).
